### PR TITLE
fix requirements conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ psutil>=5.6.2
 Pyro4>=4.76
 getch>=1.0; sys_platform != 'win32' and sys_platform != 'cygwin'
 coloredlogs>=10.0
-matplotlib>=3.2.2
+matplotlib==3.2.2
 dill>=0.3.1.1
 daemoniker>=0.2.3
 xmltodict==0.12.0


### PR DESCRIPTION
There is a conflict between `matplotlib>3.2.2` that requires `pyparsing>2.0.1` and `packaging` that requires `pyparsing<=2.0.1`. There may be more elegant solution to this but at least this one works.